### PR TITLE
Plug soundness hold around mem::forgetting MoveRefs

### DIFF
--- a/src/move_ref.rs
+++ b/src/move_ref.rs
@@ -18,6 +18,7 @@
 
 use core::marker::Unpin;
 use core::mem;
+use core::mem::ManuallyDrop;
 use core::mem::MaybeUninit;
 use core::ops::Deref;
 use core::ops::DerefMut;
@@ -38,14 +39,30 @@ use alloc::{boxed::Box, rc::Rc, sync::Arc};
 /// The main mechanism for obtaining `MoveRef`s is the [`moveit!()`] macro,
 /// which is analogous to a theoretical `&move expr` operator. This actuates
 /// a [`DerefMove`] implementation.
+///
+/// # Drop Flags
+///
+/// In order to be sound, a `MoveRef` must also hold a pointer to a drop flag,
+/// which is used to detect if the `MoveRef` was dropped without destruction.
+/// See [`DerefMove`] for more discussion on drop flags.
+///
+/// In general, [`mem::forget`]ing a `MoveRef` is a very, very bad idea. In the
+/// best case it will leak memory, but in some cases will crash the program in
+/// order to observe safety guarantees.
 pub struct MoveRef<'a, T: ?Sized> {
   ptr: &'a mut T,
+  drop_flag: Option<&'a mut DropFlag>,
 }
 
 impl<'a, T: ?Sized> MoveRef<'a, T> {
-  /// Create a new `MoveRef<T>` out of a mutable reference.
+  /// Create a new `MoveRef<T>` out of a mutable reference without a drop flag.
   ///
   /// # Safety
+  ///
+  /// This function is **extremely dangerous**, since it does not carry a drop
+  /// flag. This means that the source will not be informed of `ptr` being
+  /// forgotten, leading to all kinds of mayhem. Don't use this function unless
+  /// you really know what you're doing.
   ///
   /// `ptr` must satisfy the *longest-lived* criterion: after the return value
   /// goes out of scope, `ptr` must also be out-of-scope. Calling this function
@@ -54,8 +71,36 @@ impl<'a, T: ?Sized> MoveRef<'a, T> {
   /// In particular, if `ptr` outlives the returned `MoveRef`, it will point
   /// to dropped memory, which is UB.
   #[inline]
-  pub unsafe fn new_unchecked(ptr: &'a mut T) -> Self {
-    Self { ptr }
+  pub unsafe fn new_unchecked_without_drop_flag(ptr: &'a mut T) -> Self {
+    Self {
+      ptr,
+      drop_flag: None,
+    }
+  }
+
+  /// Create a new `MoveRef<T>` out of a mutable reference and the specified
+  /// drop flag.
+  ///
+  /// # Safety
+  /// `drop_flag`'s value *must* be [`DropFlag::Alive`], and must be a drop
+  /// flag governing the destruction of `*ptr`.
+  ///
+  /// `ptr` must satisfy the *longest-lived* criterion: after the return value
+  /// goes out of scope, `ptr` must also be out-of-scope. Calling this function
+  /// correctly is non-trivial, and should be left to [`moveit!()`] instead.
+  ///
+  /// In particular, if `ptr` outlives the returned `MoveRef`, it will point
+  /// to dropped memory, which is UB.
+  #[inline]
+  pub unsafe fn new_unchecked(
+    ptr: &'a mut T,
+    drop_flag: &'a mut DropFlag,
+  ) -> Self {
+    debug_assert!(*drop_flag == DropFlag::Alive);
+    Self {
+      ptr,
+      drop_flag: Some(drop_flag),
+    }
   }
 
   /// Convert a `MoveRef<T>` into a `Pin<MoveRef<T>>`.
@@ -113,42 +158,50 @@ impl<T: ?Sized> DerefMut for MoveRef<'_, T> {
 }
 
 unsafe impl<'a, T> DerefMove for MoveRef<'a, T> {
-  type Uninit = MoveRef<'a, MaybeUninit<T>>;
+  type Uninit = ForgetIfForgotten<MoveRef<'a, MaybeUninit<T>>>;
 
   #[inline]
-  fn deinit(self) -> Self::Uninit {
-    MoveRef {
+  fn deinit(mut self) -> Self::Uninit {
+    let ptr = MoveRef {
       ptr: unsafe { &mut *(self.ptr as *mut T as *mut MaybeUninit<T>) },
-    }
+      drop_flag: self.drop_flag.take(),
+    };
+    ForgetIfForgotten::new(ptr)
   }
 
   #[inline]
   unsafe fn deref_move(this: &mut Self::Uninit) -> MoveRef<Self::Target> {
-    MoveRef::new_unchecked(&mut *(this.ptr as *mut MaybeUninit<T> as *mut T))
+    let (ptr, df) = this.ptrs();
+    MoveRef::new_unchecked(&mut *(ptr as *mut _ as *mut T), df)
   }
 }
 
 unsafe impl<'a, T> DerefMove for MoveRef<'a, [T]> {
-  type Uninit = MoveRef<'a, [MaybeUninit<T>]>;
+  type Uninit = ForgetIfForgotten<MoveRef<'a, [MaybeUninit<T>]>>;
 
   #[inline]
-  fn deinit(self) -> Self::Uninit {
-    MoveRef {
+  fn deinit(mut self) -> Self::Uninit {
+    let ptr = MoveRef {
       ptr: unsafe { &mut *(self.ptr as *mut [T] as *mut [MaybeUninit<T>]) },
-    }
+      drop_flag: self.drop_flag.take(),
+    };
+    ForgetIfForgotten::new(ptr)
   }
 
   #[inline]
   unsafe fn deref_move(this: &mut Self::Uninit) -> MoveRef<Self::Target> {
-    MoveRef::new_unchecked(
-      &mut *(this.ptr as *mut [MaybeUninit<T>] as *mut [T]),
-    )
+    let (ptr, df) = this.ptrs();
+    MoveRef::new_unchecked(&mut *(ptr as *mut _ as *mut [T]), df)
   }
 }
 
 impl<T: ?Sized> Drop for MoveRef<'_, T> {
   #[inline]
   fn drop(&mut self) {
+    if let Some(df) = self.drop_flag.take() {
+      debug_assert!(*df == DropFlag::Alive);
+      *df = DropFlag::Dead;
+    }
     unsafe { ptr::drop_in_place(self.ptr) }
   }
 }
@@ -183,11 +236,28 @@ impl<'a, T> From<MoveRef<'a, T>> for Pin<MoveRef<'a, T>> {
 /// # Principle of Operation
 ///
 /// Unfortunately, because we don't yet have language support for `&move`, we
-/// need to break the implementation into two steps:
-/// - Inhibit the "inner destructor" of the pointee, so that the smart pointer
-///   is now managing dumb bytes. This is usually accomplished by converting the
-///   pointee type to [`MaybeUninit<T>`].
-/// - Extract a [`MoveRef`] out of the "deinitialized" pointer.
+/// need to separate the destructor of the smart pointer into two pieces:
+/// an inner destructor (the destructor of the pointee) and an outer destructor
+/// (the destructor of the smart pointer's storage).
+///
+/// Because the destructor is now split, this also requires splitting the
+/// [drop flags](https://doc.rust-lang.org/nomicon/drop-flags.html);
+/// the outer drop flag is still managed by the language, but the inner drop
+/// flag is a `moveit`-managed [`DropFlag`]. The drop flag is used to detect
+/// whether a `MoveRef` was forgotten. In general, this is an exceptional
+/// circumstance with only two possible resolutions:
+///
+/// - Leak the smart pointer's storage.
+/// - Failing that, crash the program.
+///
+/// These measures are *required* to uphold the [`Pin`] destruction guarantee.
+///
+/// Implementing `DerefMove` consists of two steps:
+/// - Converting the pointer into a destructor-inhibited form, such as wrapping
+///   in `[MaybeUninit<T>]` (`ManuallyDrop` is not recommended due to potential
+///   aliasing traps). The new form should also include a drop flag for
+///   detecting if the [`MoveRef`] was forgotten.
+/// - Extracting the inner pointer and the drop flag to form a [`MoveRef`].
 ///
 /// The first part is used to root the storage to the stack in such a way that
 /// the putative `MoveRef` can run the destructor without a double-free
@@ -310,6 +380,7 @@ pub trait PinExt<P: DerefMove> {
 impl<P: DerefMove> PinExt<P> for Pin<P> {
   fn as_move(mut this: MoveRef<Pin<P>>) -> Pin<MoveRef<P::Target>> {
     unsafe {
+      let drop_flag = this.drop_flag.take();
       let inner = Pin::get_unchecked_mut(Pin::as_mut(&mut *this));
       // Extend the lifetime of `inner` to unlink it from `this`. Because we
       // own `this`'s pointee, this is safe.
@@ -317,7 +388,115 @@ impl<P: DerefMove> PinExt<P> for Pin<P> {
       // This may be an aliasing violation because `inner` and `this` briefly
       // alias; this may be dealt with by passing `inner` through a raw pointer.
       mem::forget(this);
-      MoveRef::into_pin(MoveRef::new_unchecked(inner))
+      MoveRef::into_pin(MoveRef {
+        ptr: inner,
+        drop_flag,
+      })
+    }
+  }
+}
+
+/// The state of a drop flag. See [`MoveRef`] and [`DerefMove`].
+///
+/// See also the [Rustonomicon entry](https://doc.rust-lang.org/nomicon/drop-flags.html).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DropFlag {
+  /// The value is currently alive.
+  Alive,
+  /// The value has been destroyed.
+  Dead,
+}
+
+/// A helper for implementing `DerefMove` on a heap-allocating smart pointer.
+pub struct ForgetIfForgotten<P> {
+  flag: DropFlag,
+  ptr: ManuallyDrop<P>,
+}
+
+impl<P> ForgetIfForgotten<P> {
+  /// Creates a new `ForgetTrap`.
+  pub fn new(ptr: P) -> Self {
+    Self {
+      flag: DropFlag::Alive,
+      ptr: ManuallyDrop::new(ptr),
+    }
+  }
+
+  /// Returns pointers to the inner pointer and the flag.
+  pub fn ptrs(&mut self) -> (&mut P::Target, &mut DropFlag)
+  where
+    P: DerefMut,
+  {
+    (self.ptr.deref_mut().deref_mut(), &mut self.flag)
+  }
+}
+
+impl<P> Drop for ForgetIfForgotten<P> {
+  fn drop(&mut self) {
+    if self.flag == DropFlag::Dead {
+      unsafe { ManuallyDrop::drop(&mut self.ptr) }
+    } else if cfg!(test) {
+      // See the `forget_box` test below.
+      panic!("a critical drop flag was not flipped due to mem::forget()")
+    }
+  }
+}
+
+/// A helper for implementing `DerefMove` on a stack-allocating smart pointer.
+///
+/// If a value of this type is dropped after being [armed][ForgetTrap::arm] but
+/// without the drop flag being flipped back by a [`DerefMove`], it will
+/// will abort (*not* panic) the program.
+pub struct ForgetTrap {
+  flag: DropFlag,
+}
+
+impl ForgetTrap {
+  /// Creates a new `ForgetTrap`.
+  ///
+  /// The trap will not be sprung unless [`ForgetTrap::arm()`] is called.
+  pub fn new() -> Self {
+    Self {
+      flag: DropFlag::Dead,
+    }
+  }
+
+  /// Arms the trap; the flag must be reset to prevent it from going off.
+  pub fn arm(&mut self) {
+    self.flag = DropFlag::Alive
+  }
+
+  /// Returns a pointer to the inner flag.
+  pub fn flag(&mut self) -> &mut DropFlag {
+    &mut self.flag
+  }
+}
+
+impl Default for ForgetTrap {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl Drop for ForgetTrap {
+  fn drop(&mut self) {
+    if self.flag == DropFlag::Alive {
+      // We can force an abort by triggering a panic mid-unwind.
+      // This is the only way to force an LLVM abort from inside of `core`.
+      struct DoublePanic;
+      impl Drop for DoublePanic {
+        fn drop(&mut self) {
+          // In tests, we don't double-panic so that we can observe the failure
+          // correctly.
+          if cfg!(not(test)) {
+            panic!()
+          }
+        }
+      }
+
+      let _dp = DoublePanic;
+      panic!("a critical drop flag was not flipped due to mem::forget()")
     }
   }
 }
@@ -415,4 +594,27 @@ macro_rules! moveit {
     $crate::slot!(slot);
     let $($mut)? $name $(: $ty)? = slot.emplace($expr);
   };
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::new;
+
+  #[test]
+  #[should_panic]
+  fn forget_slot() {
+    moveit!(let x = new::of(5));
+    mem::forget(x);
+  }
+
+  #[test]
+  #[should_panic]
+  fn forget_box() {
+    // In test configurations, leaking a ForgetIfForgotten will panic,
+    // specifically for this test to work.
+    let x = Box::new(5);
+    moveit!(let y = &move *x);
+    mem::forget(y);
+  }
 }


### PR DESCRIPTION
The Pin drop invariant requires that pinned data be properly destroyed
before its memory be re-used. This is a problem: MoveRef is responsible
for running the destructor of storage it generally does not own. This
means we must leak the storage of a forgotten MoveRef. This commit
introduces explicit library-tracked drop flags to manage this corner
case.

In the case of stack-pinned MoveRefs via `slot`, we can get into
situations (such as if a constructor panics) where we cannot properly
destroy the pointee. For now, we double-panic to force an abort, but we
may be able to handle this better in the future.