### PR TITLE
Run tests under MIRI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,13 @@ jobs:
       run: cargo test --verbose
     - name: cargo doc
       run: cargo doc --verbose
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: rustup component add miri
+      run: rustup +nightly-2021-10-10 component add miri
+    - name: cargo miri test
+      run: cargo +nightly-2021-10-10 miri test --verbose

--- a/src/new/impls.rs
+++ b/src/new/impls.rs
@@ -147,7 +147,7 @@ trivial_copy! {
   core::time::Duration,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 trivial_copy! {
   alloc::boxed::Box<T> where [T],
 


### PR DESCRIPTION
Not only does this fix a double-free in `<MoveRef as DerefMove>`, but it also found a soundness issue in `PinEx::as_move`, which I've removed altogether, since it can't be made to work at all (see commit messages for details).

Closes #15.