### PR TITLE
Fix unsoundness due to DerefMove impls for Pin

### DIFF
--- a/cxx-tests/src/tests.rs
+++ b/cxx-tests/src/tests.rs
@@ -19,7 +19,6 @@ use std::sync::MutexGuard;
 use cxx::UniquePtr;
 use moveit::moveit;
 use moveit::Emplace;
-use moveit::EmplaceUnpinned;
 
 #[cxx::bridge]
 mod ffi {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.55.0"
+channel = "1.68.2"
 profile = "default"

--- a/src/alloc_support.rs
+++ b/src/alloc_support.rs
@@ -21,15 +21,28 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::sync::Arc;
 
-use crate::move_ref::DerefMove;
 use crate::move_ref::MoveRef;
+use crate::move_ref::{AsMove, DerefMove};
 use crate::new::EmplaceUnpinned;
 use crate::new::TryNew;
 use crate::slot::DroppingSlot;
 
-unsafe impl<T> DerefMove for Box<T> {
+impl<T> AsMove for Box<T> {
   type Storage = Box<MaybeUninit<T>>;
 
+  #[inline]
+  fn as_move<'frame>(
+    self,
+    storage: DroppingSlot<'frame, Self::Storage>,
+  ) -> Pin<MoveRef<'frame, Self::Target>>
+  where
+    Self: 'frame,
+  {
+    MoveRef::into_pin(self.deref_move(storage))
+  }
+}
+
+unsafe impl<T> DerefMove for Box<T> {
   #[inline]
   fn deref_move<'frame>(
     self,
@@ -87,14 +100,14 @@ impl<T> EmplaceUnpinned<T> for Pin<Arc<T>> {
 
 #[cfg(test)]
 mod tests {
-  // use crate::move_ref::test::Immovable;
-  // use crate::moveit;
-  // use crate::new::mov;
-  // use crate::Emplace;
+  use crate::move_ref::test::Immovable;
+  use crate::moveit;
+  use crate::new::mov;
+  use crate::Emplace;
 
-  // #[test]
-  // fn test_mov_box() {
-  //   let foo = Box::emplace(Immovable::new());
-  //   moveit!(let _foo = mov(foo));
-  // }
+  #[test]
+  fn test_mov_box() {
+    let foo = Box::emplace(Immovable::new());
+    moveit!(let _foo = mov(foo));
+  }
 }

--- a/src/alloc_support.rs
+++ b/src/alloc_support.rs
@@ -46,22 +46,6 @@ unsafe impl<T> DerefMove for Box<T> {
   }
 }
 
-unsafe impl<T> DerefMove for Pin<Box<T>> {
-  type Storage = <Box<T> as DerefMove>::Storage;
-
-  #[inline]
-  fn deref_move<'frame>(
-    self,
-    storage: DroppingSlot<'frame, Self::Storage>,
-  ) -> MoveRef<'frame, Self::Target>
-  where
-    Self: 'frame,
-  {
-    // Safety: boxes never move their contents
-    unsafe { Pin::into_inner_unchecked(self).deref_move(storage) }
-  }
-}
-
 impl<T> EmplaceUnpinned<T> for Pin<Box<T>> {
   fn try_emplace<N: TryNew<Output = T>>(n: N) -> Result<Self, N::Error> {
     let mut uninit = Box::new(MaybeUninit::<T>::uninit());
@@ -103,14 +87,14 @@ impl<T> EmplaceUnpinned<T> for Pin<Arc<T>> {
 
 #[cfg(test)]
 mod tests {
-  use crate::move_ref::test::Immovable;
-  use crate::moveit;
-  use crate::new::mov;
-  use crate::Emplace;
+  // use crate::move_ref::test::Immovable;
+  // use crate::moveit;
+  // use crate::new::mov;
+  // use crate::Emplace;
 
-  #[test]
-  fn test_mov_box() {
-    let foo = Box::emplace(Immovable::new());
-    moveit!(let _foo = mov(foo));
-  }
+  // #[test]
+  // fn test_mov_box() {
+  //   let foo = Box::emplace(Immovable::new());
+  //   moveit!(let _foo = mov(foo));
+  // }
 }

--- a/src/alloc_support.rs
+++ b/src/alloc_support.rs
@@ -18,13 +18,9 @@ use core::mem::MaybeUninit;
 use core::pin::Pin;
 
 use alloc::boxed::Box;
-use alloc::rc::Rc;
-use alloc::sync::Arc;
 
 use crate::move_ref::MoveRef;
 use crate::move_ref::{AsMove, DerefMove};
-use crate::new::EmplaceUnpinned;
-use crate::new::TryNew;
 use crate::slot::DroppingSlot;
 
 impl<T> AsMove for Box<T> {
@@ -56,45 +52,6 @@ unsafe impl<T> DerefMove for Box<T> {
 
     let (storage, drop_flag) = storage.put(cast);
     unsafe { MoveRef::new_unchecked(storage.assume_init_mut(), drop_flag) }
-  }
-}
-
-impl<T> EmplaceUnpinned<T> for Pin<Box<T>> {
-  fn try_emplace<N: TryNew<Output = T>>(n: N) -> Result<Self, N::Error> {
-    let mut uninit = Box::new(MaybeUninit::<T>::uninit());
-    unsafe {
-      let pinned = Pin::new_unchecked(&mut *uninit);
-      n.try_new(pinned)?;
-      Ok(Pin::new_unchecked(Box::from_raw(
-        Box::into_raw(uninit).cast::<T>(),
-      )))
-    }
-  }
-}
-
-impl<T> EmplaceUnpinned<T> for Pin<Rc<T>> {
-  fn try_emplace<N: TryNew<Output = T>>(n: N) -> Result<Self, N::Error> {
-    let uninit = Rc::new(MaybeUninit::<T>::uninit());
-    unsafe {
-      let pinned = Pin::new_unchecked(&mut *(Rc::as_ptr(&uninit) as *mut _));
-      n.try_new(pinned)?;
-      Ok(Pin::new_unchecked(Rc::from_raw(
-        Rc::into_raw(uninit).cast::<T>(),
-      )))
-    }
-  }
-}
-
-impl<T> EmplaceUnpinned<T> for Pin<Arc<T>> {
-  fn try_emplace<N: TryNew<Output = T>>(n: N) -> Result<Self, N::Error> {
-    let uninit = Arc::new(MaybeUninit::<T>::uninit());
-    unsafe {
-      let pinned = Pin::new_unchecked(&mut *(Arc::as_ptr(&uninit) as *mut _));
-      n.try_new(pinned)?;
-      Ok(Pin::new_unchecked(Arc::from_raw(
-        Arc::into_raw(uninit).cast::<T>(),
-      )))
-    }
   }
 }
 

--- a/src/cxx_support.rs
+++ b/src/cxx_support.rs
@@ -23,7 +23,7 @@ use cxx::UniquePtr;
 use crate::move_ref::AsMove;
 use crate::slot::DroppingSlot;
 use crate::DerefMove;
-use crate::EmplaceUnpinned;
+use crate::Emplace;
 use crate::MoveRef;
 use crate::TryNew;
 
@@ -63,7 +63,9 @@ pub unsafe trait MakeCppStorage: Sized {
   unsafe fn free_uninitialized_cpp_storage(ptr: *mut Self);
 }
 
-impl<T: MakeCppStorage + UniquePtrTarget> EmplaceUnpinned<T> for UniquePtr<T> {
+impl<T: MakeCppStorage + UniquePtrTarget> Emplace<T> for UniquePtr<T> {
+  type Output = Self;
+
   fn try_emplace<N: TryNew<Output = T>>(n: N) -> Result<Self, N::Error> {
     unsafe {
       let uninit_ptr = T::allocate_uninitialized_cpp_storage();

--- a/src/drop_flag.rs
+++ b/src/drop_flag.rs
@@ -22,9 +22,9 @@
 //! Normally, this isn't a problem for Rust code, since the storage of an object
 //! is destroyed immediately after it is destroyed. [`DerefMove`], however,
 //! breaks this expectation: it separates the destructors from its storage and
-//! contents into two separately destroyed objects: a [`DerefMove::Storage`]
-//! and a [`MoveRef`]. If the [`MoveRef`] is [`mem::forget`]'ed, we lose: the
-//! storage will potentially be re-used.
+//! contents into two separately destroyed objects: a [`AsMove::Storage`] and a
+//! [`MoveRef`]. If the [`MoveRef`] is [`mem::forget`]'ed, we lose: the storage
+//! will potentially be re-used.
 //!
 //! Therefore, we must somehow detect that [`MoveRef`]s fail to be destroyed
 //! when the destructor for the corresponding storage is run, and remediate it,
@@ -61,7 +61,7 @@ use core::ops::DerefMut;
 
 #[cfg(doc)]
 use {
-  crate::move_ref::{DerefMove, MoveRef},
+  crate::move_ref::{AsMove, DerefMove, MoveRef},
   alloc::boxed::Box,
   core::pin::Pin,
 };
@@ -132,9 +132,9 @@ impl DropFlag<'_> {
 /// flag can be used to signal whether to destroy or leak the value, but the
 /// destruction occurs lazily rather than immediately when the flag is flipped.
 ///
-/// This is useful as a [`DerefMove::Storage`] type for types where the
-/// storage should be leaked if the inner type was somehow not destroyed, such
-/// as in the case of heap-allocated storage like [`Box<T>`].
+/// This is useful as an [`AsMove::Storage`] type for types where the storage
+/// should be leaked if the inner type was somehow not destroyed, such as in
+/// the case of heap-allocated storage like [`Box<T>`].
 pub struct DroppingFlag<T> {
   value: ManuallyDrop<T>,
   counter: Cell<usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub mod slot;
 
 // #[doc(inline)]
 pub use crate::{
-  move_ref::{DerefMove, MoveRef},
+  move_ref::{AsMove, DerefMove, MoveRef},
   new::{CopyNew, Emplace, EmplaceUnpinned, MoveNew, New, TryNew},
   slot::Slot,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub mod slot;
 // #[doc(inline)]
 pub use crate::{
   move_ref::{AsMove, DerefMove, MoveRef},
-  new::{CopyNew, Emplace, EmplaceUnpinned, MoveNew, New, TryNew},
+  new::{CopyNew, Emplace, MoveNew, New, TryNew},
   slot::Slot,
 };
 

--- a/src/move_ref.rs
+++ b/src/move_ref.rs
@@ -177,7 +177,108 @@ impl<'a, T> From<MoveRef<'a, T>> for Pin<MoveRef<'a, T>> {
   }
 }
 
+/// A trait for getting a pinned [`MoveRef`] for some pointer type `Self`.
+///
+/// Conceptually, this trait is similar to [`DerefMove`], except that where
+/// [`DerefMove::deref_move`] produces a `MoveRef<T>`, [`AsMove::as_move`] produces a
+/// `Pin<MoveRef<T>>`.
+///
+/// `DerefMove` can be seen as a refinement of `AsMove` where stronger guarantees about the memory
+/// behavior (specifically the Pin-safety) of `Self` are present.
+///
+/// Codifying this notion is the fact that `DerefMove` requires that `Self: DerefMut + AsMove`,
+/// whereas `AsMove` only requires the weaker constraints of `Self: Deref`.
+///
+/// Although `AsMove` is a supertrait of `DerefMove`, but `DerefMove` is *not* a supertrait of
+/// `AsMove`, the two traits are nevertheless intended to have their impls for a given type defined
+/// together *simultanteously*.
+///
+/// It is expected in this situation that the impl for one of the traits will be (trivially) defined
+/// in terms of the other, depending on the API for the pointer type `Self` with respect to
+/// [`DerefMut`].
+///
+/// For example, the `Box<T>: AsMove` impl is defined in terms of the `Box<T>: DerefMove` impl,
+/// because it is always the case that `Box<T>: DerefMut` regardless of whether `T: Unpin`. Hence,
+/// `Box<T>: AsMove` simply performs the `Box<T>: DerefMove` operation then subsequently
+/// (and trivially) pins the resulting `MoveRef<T>` with [`MoveRef::into_pin`].
+///
+/// On the other hand, the `cxx::UniquePtr<T>: DerefMove` impl is defined in terms of the
+/// `UniquePtr<T>: AsMove` impl, because a `cxx::UniquePtr<T>: DerefMut` only if `T: Unpin`. Given
+/// that `cxx::UniquePtr<T>` behaves like `Pin<Box<T>>` with respect to `DerefMut`, it is always
+/// possible to safely produce a `Pin<MoveRef<T>>`, but *not* always possible to safely produce a
+/// `MoveRef<T>`. Hence, when `T: Unpin`, only then `cxx::UniquePtr<T>: DerefMove` is defined,
+/// which simply performs the `cxx::UniquePtr<T>: AsMove` operation then subsequently
+/// (and trivially) unpins the resulting `Pin<MoveRef<T>>` with [`Pin::into_inner`].
+pub trait AsMove: Deref + Sized {
+  /// The "pure storage" form of `Self`, which owns the storage but not the
+  /// pointee.
+  type Storage: Sized;
+
+  /// Gets a pinned `MoveRef` out of `Self`.
+  ///
+  /// This function is best paired with [`moveit!()`]:
+  /// ```
+  /// # use core::pin::Pin;
+  /// # use moveit::{moveit, slot::DroppingSlot, move_ref::AsMove};
+  /// let ptr = Box::pin(5);
+  /// moveit::slot!(#[dropping] storage);
+  /// ptr.as_move(storage);
+  /// ```
+  /// Taking a trip through [`moveit!()`] is unavoidable due to the nature of
+  /// `MoveRef`.
+  ///
+  /// Compare with [`Pin::as_mut()`].
+  fn as_move<'frame>(
+    self,
+    storage: DroppingSlot<'frame, Self::Storage>,
+  ) -> Pin<MoveRef<'frame, Self::Target>>
+  where
+    Self: 'frame;
+}
+
+impl<'f, T: ?Sized> AsMove for MoveRef<'f, T> {
+  type Storage = ();
+
+  #[inline]
+  fn as_move<'frame>(
+    self,
+    storage: DroppingSlot<'frame, Self::Storage>,
+  ) -> Pin<MoveRef<'frame, Self::Target>>
+  where
+    Self: 'frame,
+  {
+    MoveRef::into_pin(DerefMove::deref_move(self, storage))
+  }
+}
+
+impl<P: DerefMove> AsMove for Pin<P> {
+  type Storage = P::Storage;
+
+  #[inline]
+  fn as_move<'frame>(
+    self,
+    storage: DroppingSlot<'frame, Self::Storage>,
+  ) -> Pin<MoveRef<'frame, Self::Target>>
+  where
+    Self: 'frame,
+  {
+    unsafe {
+      // SAFETY:
+      //
+      // It is safe to unwrap the `Pin` because `deref_move()` must not move out of the actual
+      // storage, merely shuffle pointers around, and immediately after the call to `deref_move()`
+      // we repin with `MoveRef::into_pin`, so the `Pin` API invariants are not violated later.
+      MoveRef::into_pin(P::deref_move(Pin::into_inner_unchecked(self), storage))
+    }
+  }
+}
+
 /// Moving dereference operations.
+///
+/// *Note: This trait is intended to be defined in conjunction with [`AsMove`],
+/// and there is a subtle interdependency between the two traits. We recommend
+/// also reading it's documentation for a better understanding of how these
+/// traits fit together.*
 ///
 /// This trait is the `&move` analogue of [`Deref`], for taking a pointer that
 /// is the *sole owner* its pointee and converting it to a [`MoveRef`]. In
@@ -208,7 +309,7 @@ impl<'a, T> From<MoveRef<'a, T>> for Pin<MoveRef<'a, T>> {
 ///
 /// The first part of this consists of converting the pointer into the
 /// "partially deinitialized" form, represented by the type
-/// [`DerefMove::Storage`]: it is the pointer as "pure storage".
+/// [`AsMove::Storage`]: it is the pointer as "pure storage".
 ///
 /// This pointer should be placed into the [`DroppingSlot`] passed into
 /// `deref_move`, so that it has a fixed lifetime for the duration of the frame
@@ -226,7 +327,7 @@ impl<'a, T> From<MoveRef<'a, T>> for Pin<MoveRef<'a, T>> {
 /// ## Worked Example: [`Box<T>`]
 ///
 /// To inhibit the inner destructor of [`Box<T>`], we can use `Box<MaybeUninit<T>>`
-/// as [`DerefMove::Storage`]. [`MaybeUninit`] is preferred over [`ManuallyDrop`],
+/// as [`AsMove::Storage`]. [`MaybeUninit`] is preferred over [`ManuallyDrop`],
 /// since it helps avoid otherwise scary aliasing problems with `Box<&mut T>`.
 ///
 /// The first step is to "cast" `Box<T>` into `Box<MaybeUninit<T>>` via
@@ -252,7 +353,7 @@ impl<'a, T> From<MoveRef<'a, T>> for Pin<MoveRef<'a, T>> {
 ///
 /// We don't need to inhibit any destructors: we just need to convert a
 /// `MoveRef<MoveRef<T>>` into a `MoveRef<T>`, which we can do by using
-/// [`MoveRef::into_inner()`]. [`DerefMove::Storage`] can be whatever, so we
+/// [`MoveRef::into_inner()`]. [`AsMove::Storage`] can be whatever, so we
 /// simply choose [`()`] for this; the choice is arbitrary.
 ///
 /// # Safety
@@ -284,13 +385,9 @@ impl<'a, T> From<MoveRef<'a, T>> for Pin<MoveRef<'a, T>> {
 ///
 /// `deref_move()` must also be `Pin`-safe; even though it does not accept a
 /// pinned reference, it must take care to not move its contents at any time.
-/// In particular, the implementation of [`PinExt::as_move()`] must be safe by
+/// In particular, the implementation of [`AsMove::as_move()`] must be safe by
 /// definition.
-pub unsafe trait DerefMove: Deref + Sized {
-  /// The "pure storage" form of `Self`, which owns the storage but not the
-  /// pointee.
-  type Storage: Sized;
-
+pub unsafe trait DerefMove: DerefMut + AsMove {
   /// Moves out of `self`, producing a [`MoveRef`] that owns its contents.
   ///
   /// `storage` is a location *somewhere* responsible for rooting the lifetime
@@ -307,13 +404,11 @@ pub unsafe trait DerefMove: Deref + Sized {
 }
 
 unsafe impl<'a, T: ?Sized> DerefMove for MoveRef<'a, T> {
-  type Storage = ();
-
   #[inline]
   fn deref_move<'frame>(
     self,
-    _storage: DroppingSlot<'frame, ()>,
-  ) -> MoveRef<'frame, T>
+    _storage: DroppingSlot<'frame, Self::Storage>,
+  ) -> MoveRef<'frame, Self::Target>
   where
     Self: 'frame,
   {
@@ -323,12 +418,9 @@ unsafe impl<'a, T: ?Sized> DerefMove for MoveRef<'a, T> {
 
 unsafe impl<P> DerefMove for Pin<P>
 where
-  P: DerefMove + DerefMut,
-  P::Target: Unpin,
+  P: DerefMove, // needed for `AsMove: Pin<P>` for the call to `Self::as_move`
+  P::Target: Unpin, // needed for the call to `Pin::into_inner`
 {
-  // SAFETY: We do not need to pin the storage, because `P::Target: Unpin`.
-  type Storage = P::Storage;
-
   #[inline]
   fn deref_move<'frame>(
     self,
@@ -337,52 +429,7 @@ where
   where
     Self: 'frame,
   {
-    Pin::into_inner(Pin::as_move(self, storage))
-  }
-}
-
-/// Extensions for using `DerefMove` types with `PinExt`.
-pub trait PinExt<P: DerefMove> {
-  /// Gets a pinned `MoveRef` out of the pinned pointer.
-  ///
-  /// This function is best paired with [`moveit!()`]:
-  /// ```
-  /// # use core::pin::Pin;
-  /// # use moveit::{moveit, slot::DroppingSlot, move_ref::PinExt as _};
-  /// let ptr = Box::pin(5);
-  /// moveit::slot!(#[dropping] storage);
-  /// Pin::as_move(ptr, storage);
-  /// ```
-  /// Taking a trip through [`moveit!()`] is unavoidable due to the nature of
-  /// `MoveRef`.
-  ///
-  /// Compare with [`Pin::as_mut()`].
-  fn as_move<'frame>(
-    self,
-    storage: DroppingSlot<'frame, P::Storage>,
-  ) -> Pin<MoveRef<'frame, P::Target>>
-  where
-    Self: 'frame;
-}
-
-impl<P: DerefMove> PinExt<P> for Pin<P> {
-  fn as_move<'frame>(
-    self,
-    storage: DroppingSlot<'frame, P::Storage>,
-  ) -> Pin<MoveRef<'frame, P::Target>>
-  where
-    Self: 'frame,
-  {
-    unsafe {
-      // SAFETY:
-      // 1. `Pin<P>` is `repr(transparent)` and can transmute to `P`.
-      // 2. `deref_move()` must not move out of the actual storage, merely
-      //    shuffle pointers around.
-      MoveRef::into_pin(DerefMove::deref_move(
-        Pin::into_inner_unchecked(self),
-        storage,
-      ))
-    }
+    Pin::into_inner(self.as_move(storage))
   }
 }
 
@@ -517,9 +564,9 @@ macro_rules! moveit {
 
 #[cfg(test)]
 pub(crate) mod test {
-  // use crate::new;
+  use crate::new;
   use crate::MoveNew;
-  // use crate::New;
+  use crate::New;
 
   use super::*;
   use std::alloc;
@@ -605,9 +652,9 @@ pub(crate) mod test {
   }
 
   impl Immovable {
-    // pub(crate) fn new() -> impl New<Output = Self> {
-    //   new::default()
-    // }
+    pub(crate) fn new() -> impl New<Output = Self> {
+      new::default()
+    }
   }
 
   unsafe impl MoveNew for Immovable {
@@ -618,11 +665,11 @@ pub(crate) mod test {
     }
   }
 
-  // #[test]
-  // fn test_mov() {
-  //   moveit! {
-  //     let foo = Immovable::new();
-  //     let _foo = new::mov(foo);
-  //   }
-  // }
+  #[test]
+  fn test_mov() {
+    moveit! {
+      let foo = Immovable::new();
+      let _foo = new::mov(foo);
+    }
+  }
 }

--- a/src/move_ref.rs
+++ b/src/move_ref.rs
@@ -51,7 +51,7 @@ use core::ptr;
 
 #[cfg(doc)]
 use {
-  crate::drop_flag,
+  crate::{drop_flag, moveit},
   alloc::{boxed::Box, rc::Rc, sync::Arc},
   core::mem::{ManuallyDrop, MaybeUninit},
 };

--- a/src/move_ref.rs
+++ b/src/move_ref.rs
@@ -321,62 +321,6 @@ unsafe impl<'a, T: ?Sized> DerefMove for MoveRef<'a, T> {
   }
 }
 
-unsafe impl<'a, T> DerefMove for Pin<&'a T>
-where
-  Pin<&'a T>: DerefMove + DerefMut,
-  Pin<&'a T>: Deref<Target = T>,
-  T: Unpin,
-{
-  // SAFETY: We do not need to pin the storage, because `P::Target: Unpin`.
-  type Storage = Self;
-
-  #[inline]
-  fn deref_move<'frame>(
-    self,
-    storage: DroppingSlot<'frame, Self::Storage>,
-  ) -> MoveRef<'frame, Self::Target>
-  where
-    Self: 'frame,
-  {
-    Pin::into_inner(MoveRef::into_pin(DerefMove::deref_move(self, storage)))
-  }
-}
-
-unsafe impl<'a, T> DerefMove for Pin<&'a mut T>
-where
-  Pin<&'a mut T>: DerefMove + DerefMut,
-  Pin<&'a mut T>: Deref<Target = T>,
-  T: Unpin,
-{
-  // SAFETY: We do not need to pin the storage, because `P::Target: Unpin`.
-  type Storage = Self;
-
-  #[inline]
-  fn deref_move<'frame>(
-    self,
-    storage: DroppingSlot<'frame, Self::Storage>,
-  ) -> MoveRef<'frame, Self::Target>
-  where
-    Self: 'frame,
-  {
-    Pin::into_inner(MoveRef::into_pin(DerefMove::deref_move(self, storage)))
-  }
-}
-
-unsafe impl<'a, T> DerefMove for Pin<MoveRef<'a, T>> {
-  type Storage = <MoveRef<'a, T> as DerefMove>::Storage;
-
-  fn deref_move<'frame>(
-    self,
-    storage: DroppingSlot<'frame, Self::Storage>,
-  ) -> MoveRef<'frame, Self::Target>
-  where
-    Self: 'frame,
-  {
-    unsafe { Pin::into_inner_unchecked(self).deref_move(storage) }
-  }
-}
-
 /// Extensions for using `DerefMove` types with `PinExt`.
 pub trait PinExt<P: DerefMove> {
   /// Gets a pinned `MoveRef` out of the pinned pointer.
@@ -553,9 +497,9 @@ macro_rules! moveit {
 
 #[cfg(test)]
 pub(crate) mod test {
-  use crate::new;
+  // use crate::new;
   use crate::MoveNew;
-  use crate::New;
+  // use crate::New;
 
   use super::*;
   use std::alloc;
@@ -641,9 +585,9 @@ pub(crate) mod test {
   }
 
   impl Immovable {
-    pub(crate) fn new() -> impl New<Output = Self> {
-      new::default()
-    }
+    // pub(crate) fn new() -> impl New<Output = Self> {
+    //   new::default()
+    // }
   }
 
   unsafe impl MoveNew for Immovable {
@@ -654,11 +598,11 @@ pub(crate) mod test {
     }
   }
 
-  #[test]
-  fn test_mov() {
-    moveit! {
-      let foo = Immovable::new();
-      let _foo = new::mov(foo);
-    }
-  }
+  // #[test]
+  // fn test_mov() {
+  //   moveit! {
+  //     let foo = Immovable::new();
+  //     let _foo = new::mov(foo);
+  //   }
+  // }
 }

--- a/src/move_ref.rs
+++ b/src/move_ref.rs
@@ -416,6 +416,19 @@ unsafe impl<'a, T: ?Sized> DerefMove for MoveRef<'a, T> {
   }
 }
 
+/// Note that `DerefMove` cannot be used to move out of a `Pin<P>` when `P::Target: !Unpin`.
+/// ```compile_fail
+/// # use crate::{moveit::{Emplace, MoveRef, moveit}};
+/// # use core::{marker::PhantomPinned, pin::Pin};
+/// // Fails to compile because `Box<PhantomPinned>: Deref<Target = PhantomPinned>` and `PhantomPinned: !Unpin`.
+/// let ptr: Pin<Box<PhantomPinned>> = Box::emplace(moveit::new::default::<PhantomPinned>());
+/// moveit!(let mref = &move *ptr);
+///
+/// // Fails to compile because `MoveRef<PhantomPinned>: Deref<Target = PhantomPinned>` and `PhantomPinned: !Unpin`.
+/// moveit! {
+///   let mref0: Pin<MoveRef<PhantomPinned>> = moveit::new::default::<PhantomPinned>();
+///   let mref1 = &move *mref0;
+/// }
 unsafe impl<P> DerefMove for Pin<P>
 where
   P: DerefMove, // needed for `AsMove: Pin<P>` for the call to `Self::as_move`

--- a/src/new/move_new.rs
+++ b/src/new/move_new.rs
@@ -15,7 +15,7 @@
 use core::mem::MaybeUninit;
 use core::pin::Pin;
 
-use crate::move_ref::DerefMove;
+use crate::move_ref::AsMove;
 use crate::move_ref::MoveRef;
 use crate::new;
 use crate::new::New;
@@ -57,15 +57,12 @@ pub unsafe trait MoveNew: Sized {
 #[inline]
 pub fn mov<P>(ptr: P) -> impl New<Output = P::Target>
 where
-  P: DerefMove,
+  P: AsMove,
   P::Target: MoveNew,
 {
   unsafe {
     new::by_raw(move |this| {
-      MoveNew::move_new(
-        Pin::new_unchecked(ptr.deref_move(slot!(#[dropping]))),
-        this,
-      );
+      MoveNew::move_new(ptr.as_move(slot!(#[dropping])), this);
     })
   }
 }

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -68,7 +68,10 @@ use crate::new::New;
 use crate::new::TryNew;
 
 #[cfg(doc)]
-use {crate::move_ref::DerefMove, alloc::boxed::Box};
+use {
+  crate::{move_ref::DerefMove, moveit, slot},
+  alloc::boxed::Box,
+};
 
 /// An empty slot on the stack into which a value could be emplaced.
 ///


### PR DESCRIPTION
This is a follow up PR for #37, which I managed to close as I was shuffling around some changes to the repository.

This includes some additional changes since the most recent comments from that thread.

Notably, I managed to refactor `DerefMove` and `AsMove` to a have a more precise relationship and remove some of the redundancy.

In particular, the `Storage` type is now no longer duplicated but instead is only defined in `AsMove::Storage`, and further, `AsMove` is now a supertrait of `DerefMove`.

I've updated the documentation accordingly.

I did also briefly try to unify `AsMove` and `DerefMove` but it doesn't seem feasible to do this, as far as I can tell, because impls for `DerefMove::deref_move` may need additional, recursive, constraints on `Self` (having to do with `DerefMut` and `Unpin`).

I don't see a clear way to express this universally for all types ahead of time in the trait method signature for `deref_move`, keeping in mind that `where` clauses for method impls cannot contain additional, impl-specific constraints.

Thus, we are forced to split the hypothetical unified trait into two separate traits simply in order to allow these different constraints, even though each trait only has the single method.